### PR TITLE
Use a set default dimension type instead of using overworld

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/Fantasy.java
+++ b/src/main/java/xyz/nucleoid/fantasy/Fantasy.java
@@ -12,6 +12,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
+import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.level.storage.LevelStorage;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -36,6 +37,7 @@ import java.util.Set;
 public final class Fantasy {
     public static final Logger LOGGER = LogManager.getLogger(Fantasy.class);
     public static final String ID = "fantasy";
+    public static final RegistryKey<DimensionType> DEFAULT_DIM_TYPE = RegistryKey.of(Registry.DIMENSION_TYPE_KEY,  new Identifier(Fantasy.ID, "default"));
 
     private static Fantasy instance;
 

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldConfig.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldConfig.java
@@ -21,7 +21,7 @@ import xyz.nucleoid.fantasy.util.GameRuleStore;
  */
 public final class RuntimeWorldConfig {
     private long seed = 0;
-    private RegistryKey<DimensionType> dimensionTypeKey = DimensionType.OVERWORLD_REGISTRY_KEY;
+    private RegistryKey<DimensionType> dimensionTypeKey = Fantasy.DEFAULT_DIM_TYPE;
     private DimensionType dimensionType;
     private ChunkGenerator generator = null;
     private long timeOfDay = 6000;

--- a/src/main/resources/data/fantasy/dimension_type/default.json
+++ b/src/main/resources/data/fantasy/dimension_type/default.json
@@ -1,0 +1,17 @@
+{
+  "logical_height": 256,
+  "infiniburn": "minecraft:infiniburn_overworld",
+  "effects": "minecraft:overworld",
+  "ambient_light": 0.0,
+  "respawn_anchor_works": false,
+  "has_raids": true,
+  "min_y": 0,
+  "height": 256,
+  "natural": true,
+  "coordinate_scale": 1.0,
+  "piglin_safe": false,
+  "bed_works": true,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "ultrawarm": false
+}


### PR DESCRIPTION
Use a static default dimension type for RuntimeWorldConfig instead of overworld which can change.

Fixes issues with plasmid games using map templates not properly handling dimension types with negative world height. A fix for plasmid to better support worlds with negative and higher heights is recommended.