### PR TITLE
Update mod to Minecraft 1.18.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.18-pre6
-yarn_mappings=1.18-pre6+build.3
-loader_version=0.12.5
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.12
+loader_version=0.12.12
 
 # Mod Properties
 mod_version=0.4.3
@@ -12,4 +12,4 @@ maven_group=xyz.nucleoid
 archives_base_name=fantasy
 
 # Dependencies
-fabric_version=0.42.9+1.18
+fabric_version=0.45.0+1.18


### PR DESCRIPTION
This pull request builds the mod on Minecraft 1.18.1 instead of Minecraft 1.18 pre-release 6. This makes it more clear that Fantasy works on stable versions of Minecraft 1.18, but does not necessitate a new release.