### PR TITLE
Don't send rain packets to all worlds

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/mixin/ServerWorldMixin.java
+++ b/src/main/java/xyz/nucleoid/fantasy/mixin/ServerWorldMixin.java
@@ -1,5 +1,7 @@
 package xyz.nucleoid.fantasy.mixin;
 
+import net.minecraft.network.Packet;
+import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerChunkManager;
 import net.minecraft.server.world.ServerWorld;
@@ -8,6 +10,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.nucleoid.fantasy.FantasyWorldAccess;
 
@@ -52,5 +55,20 @@ public abstract class ServerWorldMixin implements FantasyWorldAccess {
 
     private boolean isWorldEmpty() {
         return this.getPlayers().isEmpty() && this.getChunkManager().getLoadedChunkCount() <= 0;
+    }
+
+    @Redirect(
+            method = "tickWeather",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/PlayerManager;sendToAll(Lnet/minecraft/network/Packet;)V"
+            )
+
+    )
+    private void dontSendRainPacketsToAllWorlds(PlayerManager instance, Packet<?> packet) {
+        // Vanilla sends rain packets to all players when rain starts in a world,
+        // even if they are not in it, meaning that if it is possible to rain in the world they are in
+        // the rain effect will remain until the player changes dimension or reconnects.
+        instance.sendToDimension(packet, this.getChunkManager().getWorld().getRegistryKey());
     }
 }


### PR DESCRIPTION
When it starts to rain Minecraft Vanilla sends the rain packet to all the worlds, this cannot be noticed in vanilla since only the rain is visible in the overworld.

If you have more than one world where it can rain like in the overworld, the rain animation will be bugged and stay on start until the player exits the world or reconnects.

Note: you can force replicate it using
```
/execute in minecraft:overworld run weather rain
```

![image](https://user-images.githubusercontent.com/63565983/182740950-678111dc-73fd-4716-83b0-92744c40771d.png)
