### PR TITLE
fix #14

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ yarn_mappings=1.19+build.1
 loader_version=0.14.9
 
 # Mod Properties
-mod_version=0.4.7
+mod_version=0.4.8
 maven_group=xyz.nucleoid
 archives_base_name=fantasy
 

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorld.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorld.java
@@ -15,6 +15,8 @@ import xyz.nucleoid.fantasy.util.VoidWorldProgressListener;
 class RuntimeWorld extends ServerWorld {
     final Style style;
 
+    final long seed;
+
     RuntimeWorld(MinecraftServer server, RegistryKey<World> registryKey, RuntimeWorldConfig config, Style style) {
         super(
                 server, Util.getMainWorkerExecutor(), ((MinecraftServerAccess) server).getSession(),
@@ -27,6 +29,7 @@ class RuntimeWorld extends ServerWorld {
                 ImmutableList.of(),
                 config.shouldTickTime()
         );
+        this.seed = config.getSeed();
         this.style = style;
     }
 
@@ -35,6 +38,11 @@ class RuntimeWorld extends ServerWorld {
         if (this.style == Style.PERSISTENT || !flush) {
             super.save(progressListener, flush, enabled);
         }
+    }
+
+    @Override
+    public long getSeed() {
+        return this.seed;
     }
 
     public enum Style {


### PR DESCRIPTION
In 1.19 the vanilla chunk generator now calls `World::getSeed()` to determine chunk generation seed. The default implementation simply uses the Overworld seed, not the configured seed for the given Fantasy world. `RuntimeWorld` now overrides this method to return the configured seed.