### PR TITLE
[1.19] Add unloading mechanism and the ability to load dimensions from arbitrary directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'fabric-loom' version '0.12-SNAPSHOT'
+  id 'fabric-loom' version '1.0-SNAPSHOT'
   id 'maven-publish'
 }
 
@@ -76,12 +76,7 @@ jar {
 publishing {
   publications {
     mavenJava(MavenPublication) {
-      artifact(remapJar) {
-        builtBy remapJar
-      }
-      artifact(sourcesJar) {
-        builtBy remapSourcesJar
-      }
+      from components.java
     }
   }
 

--- a/src/main/java/xyz/nucleoid/fantasy/FantasyInitializer.java
+++ b/src/main/java/xyz/nucleoid/fantasy/FantasyInitializer.java
@@ -1,13 +1,16 @@
 package xyz.nucleoid.fantasy;
 
 import net.fabricmc.api.ModInitializer;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import xyz.nucleoid.fantasy.util.VoidChunkGenerator;
 
 public final class FantasyInitializer implements ModInitializer {
     @Override
     public void onInitialize() {
-        Registry.register(Registry.CHUNK_GENERATOR, new Identifier(Fantasy.ID, "void"), VoidChunkGenerator.CODEC);
+        Registry.register(
+                Registry.CHUNK_GENERATOR,
+                Fantasy.VOID_CHUNK_GENERATOR,
+                VoidChunkGenerator.CODEC
+        );
     }
 }

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorld.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorld.java
@@ -8,16 +8,17 @@ import net.minecraft.util.Util;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.source.BiomeAccess;
+import net.minecraft.world.level.storage.LevelStorage;
 import org.jetbrains.annotations.Nullable;
-import xyz.nucleoid.fantasy.mixin.MinecraftServerAccess;
 import xyz.nucleoid.fantasy.util.VoidWorldProgressListener;
 
 class RuntimeWorld extends ServerWorld {
     final Style style;
 
-    RuntimeWorld(MinecraftServer server, RegistryKey<World> registryKey, RuntimeWorldConfig config, Style style) {
+    RuntimeWorld(MinecraftServer server, RegistryKey<World> registryKey, RuntimeWorldConfig config,
+                 LevelStorage.Session storageSession, Style style) {
         super(
-                server, Util.getMainWorkerExecutor(), ((MinecraftServerAccess) server).getSession(),
+                server, Util.getMainWorkerExecutor(), storageSession,
                 new RuntimeWorldProperties(server.getSaveProperties(), config),
                 registryKey,
                 config.createDimensionOptions(server),

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldHandle.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldHandle.java
@@ -21,6 +21,10 @@ public final class RuntimeWorldHandle {
         this.fantasy.enqueueWorldDeletion(this.world);
     }
 
+    public void unload() {
+        this.fantasy.enqueueWorldUnload(this.world);
+    }
+
     public ServerWorld asWorld() {
         return this.world;
     }

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
@@ -61,14 +61,7 @@ final class RuntimeWorldManager {
     }
 
     void delete(ServerWorld world) {
-        RegistryKey<World> dimensionKey = world.getRegistryKey();
-
-        if (this.serverAccess.getWorlds().remove(dimensionKey, world)) {
-            ServerWorldEvents.UNLOAD.invoker().onWorldUnload(this.server, world);
-
-            SimpleRegistry<DimensionOptions> dimensionsRegistry = getDimensionsRegistry(this.server);
-            RemoveFromRegistry.remove(dimensionsRegistry, dimensionKey.getValue());
-
+        if (this.unload(world)) {
             File worldDirectory = new File(world.getChunkManager().threadedAnvilChunkStorage.getSaveDir());
             if (worldDirectory.exists()) {
                 try {
@@ -82,6 +75,20 @@ final class RuntimeWorldManager {
                 }
             }
         }
+    }
+
+    boolean unload(ServerWorld world) {
+        RegistryKey<World> dimensionKey = world.getRegistryKey();
+
+        if (this.serverAccess.getWorlds().remove(dimensionKey, world)) {
+            ServerWorldEvents.UNLOAD.invoker().onWorldUnload(this.server, world);
+
+            SimpleRegistry<DimensionOptions> dimensionsRegistry = getDimensionsRegistry(this.server);
+            RemoveFromRegistry.remove(dimensionsRegistry, dimensionKey.getValue());
+            return true;
+        }
+
+        return false;
     }
 
     private static SimpleRegistry<DimensionOptions> getDimensionsRegistry(MinecraftServer server) {

--- a/src/main/java/xyz/nucleoid/fantasy/mixin/registry/GeneratorOptionsMixin.java
+++ b/src/main/java/xyz/nucleoid/fantasy/mixin/registry/GeneratorOptionsMixin.java
@@ -16,4 +16,5 @@ public class GeneratorOptionsMixin {
     @ModifyArg(method = "method_28606", at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/MapCodec;forGetter(Ljava/util/function/Function;)Lcom/mojang/serialization/codecs/RecordCodecBuilder;", ordinal = 3))
     private static Function<GeneratorOptions, Registry<DimensionOptions>> fantasy$wrapRegistry(Function<GeneratorOptions, Registry<DimensionOptions>> getter) {
         return (e) -> new FilteredRegistry<>(e.getDimensions(), FantasyDimensionOptions.SAVE_PREDICATE);
-    }}
+    }
+}

--- a/src/testmod/java/xyz/nucleoid/fantasy/test/FantasyInitializer.java
+++ b/src/testmod/java/xyz/nucleoid/fantasy/test/FantasyInitializer.java
@@ -1,27 +1,78 @@
 package xyz.nucleoid.fantasy.test;
 
-import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.Command;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
-import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.datafixer.Schemas;
+import net.minecraft.server.command.CommandManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.world.dimension.DimensionTypes;
+import net.minecraft.world.level.storage.LevelStorage;
 import xyz.nucleoid.fantasy.Fantasy;
 import xyz.nucleoid.fantasy.RuntimeWorldConfig;
 import xyz.nucleoid.fantasy.util.VoidChunkGenerator;
 
+import java.io.IOException;
+import java.nio.file.Path;
+
 public final class FantasyInitializer implements ModInitializer {
     @Override
     public void onInitialize() {
-        ServerLifecycleEvents.SERVER_STARTED.register((s) -> {
-            Fantasy.get(s).openTemporaryWorld(new RuntimeWorldConfig().setGenerator(new VoidChunkGenerator(s.getRegistryManager().get(Registry.BIOME_KEY).getEntry(0).get())));
-            Fantasy.get(s).getOrOpenPersistentWorld(
-                    new Identifier("fantasytest:test"),
-                    new RuntimeWorldConfig()
-                            .setGenerator(s.getOverworld().getChunkManager().getChunkGenerator())
-            );
-        });
-    }
+        var storage = new LevelStorage(
+                Path.of("test-save"),
+                Path.of("test-backup"),
+                Schemas.getFixer()
+        );
+        try {
+            var session = storage.createSession("test-session");
+            ServerLifecycleEvents.SERVER_STOPPED.register((s2) -> {
+                try {
+                    session.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
 
+            ServerLifecycleEvents.SERVER_STARTED.register((s) -> {
+                Fantasy.get(s).openTemporaryWorld(new RuntimeWorldConfig().setGenerator(new VoidChunkGenerator(s.getRegistryManager().get(Registry.BIOME_KEY).getEntry(0).get())));
+                Fantasy.get(s).getOrOpenPersistentWorld(
+                        new Identifier("fantasytest:test"),
+                        new RuntimeWorldConfig()
+                                .setGenerator(s.getOverworld().getChunkManager().getChunkGenerator())
+                );
+                System.out.println("External saves dir: " + storage.getSavesDirectory().toAbsolutePath());
+                Fantasy.get(s).getOrOpenPersistentWorld(
+                        new Identifier("fantasytest:test2"),
+                        new RuntimeWorldConfig()
+                                .setDimensionType(DimensionTypes.OVERWORLD)
+                                .setGenerator(new VoidChunkGenerator(s.getRegistryManager().get(Registry.BIOME_KEY))),
+                        session
+                );
+            });
+            CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, dedicated) -> {
+                dispatcher.register(CommandManager.literal("unload-dim").executes(context -> {
+                    Fantasy.get(context.getSource().getServer()).getOrOpenPersistentWorld(new Identifier("fantasytest:test2"), null).unload();
+                    return Command.SINGLE_SUCCESS;
+                }));
+                dispatcher.register(CommandManager.literal("load-dim").executes(context -> {
+                    try {
+                        Fantasy.get(context.getSource().getServer()).getOrOpenPersistentWorld(
+                                new Identifier("fantasytest:test2"),
+                                new RuntimeWorldConfig()
+                                        .setDimensionType(DimensionTypes.OVERWORLD)
+                                        .setGenerator(new VoidChunkGenerator(context.getSource().getServer().getRegistryManager().get(Registry.BIOME_KEY))),
+                                session
+                        );
+                    } catch (Throwable t) {
+                        t.printStackTrace();
+                    }
+                    return Command.SINGLE_SUCCESS;
+                }));
+            });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
I know, the 1.19 branch is stale, but I need this feature in 1.19.2, and I'll also port it to 1.19.3 afterward.

This pull request adds two features:
- unloading dimensions at runtime
  - Uses the delete logic, but without the deletion of the actual world directory
- loading dimensions from arbitrary directories
  - Allows to pass a custom `LevelStorage.Session` to `Fantasy.getOrOpenPersistentWorld()`