### PR TITLE
Update README to reflect 1.19+ dimension registry key changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This specifies how the dimension should be created, involving a dimension type, 
 For example, we could create a config like such:
 ```java
 RuntimeWorldConfig worldConfig = new RuntimeWorldConfig()
-        .setDimensionType(DimensionType.OVERWORLD_REGISTRY_KEY)
+        .setDimensionType(DimensionTypes.OVERWORLD)
         .setDifficulty(Difficulty.HARD)
         .setGameRule(GameRules.DO_DAYLIGHT_CYCLE, false)
         .setGenerator(server.getOverworld().getChunkManager().getChunkGenerator())


### PR DESCRIPTION
The README was last updated 2 years ago and since version 1.19 Mojang updated their Dimension Type to have their world registry keys under another class. Rendering the RuntimeWorldConfig example useless. This PR Should fix that.

NOTE: I put `1.20 changes` by accident that should have been `1.19 changes` 