### PR TITLE
Fix world unload event invocation and registry entry removal when unloading worlds

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
@@ -87,8 +87,6 @@ final class RuntimeWorldManager {
         RegistryKey<World> dimensionKey = world.getRegistryKey();
 
         if (this.serverAccess.getWorlds().remove(dimensionKey, world)) {
-            ServerWorldEvents.UNLOAD.invoker().onWorldUnload(RuntimeWorldManager.this.server, world);
-
             world.save(new ProgressListener() {
                 @Override
                 public void setTitle(Text title) {}
@@ -105,6 +103,8 @@ final class RuntimeWorldManager {
                 @Override
                 public void setDone() {}
             }, true, false);
+
+            ServerWorldEvents.UNLOAD.invoker().onWorldUnload(RuntimeWorldManager.this.server, world);
 
             SimpleRegistry<DimensionOptions> dimensionsRegistry = getDimensionsRegistry(RuntimeWorldManager.this.server);
             RemoveFromRegistry.remove(dimensionsRegistry, dimensionKey.getValue());

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
@@ -87,6 +87,8 @@ final class RuntimeWorldManager {
         RegistryKey<World> dimensionKey = world.getRegistryKey();
 
         if (this.serverAccess.getWorlds().remove(dimensionKey, world)) {
+            ServerWorldEvents.UNLOAD.invoker().onWorldUnload(RuntimeWorldManager.this.server, world);
+
             world.save(new ProgressListener() {
                 @Override
                 public void setTitle(Text title) {}
@@ -101,13 +103,11 @@ final class RuntimeWorldManager {
                 public void progressStagePercentage(int percentage) {}
 
                 @Override
-                public void setDone() {
-                    ServerWorldEvents.UNLOAD.invoker().onWorldUnload(RuntimeWorldManager.this.server, world);
-
-                    SimpleRegistry<DimensionOptions> dimensionsRegistry = getDimensionsRegistry(RuntimeWorldManager.this.server);
-                    RemoveFromRegistry.remove(dimensionsRegistry, dimensionKey.getValue());
-                }
+                public void setDone() {}
             }, true, false);
+
+            SimpleRegistry<DimensionOptions> dimensionsRegistry = getDimensionsRegistry(RuntimeWorldManager.this.server);
+            RemoveFromRegistry.remove(dimensionsRegistry, dimensionKey.getValue());
         }
     }
 


### PR DESCRIPTION
Fixes #34

Context: the "setDone" of the ProgressListener passed to `world.save()` is never called by the server or client.
I moved the content of "setDone" to after the save method. This resembles how the original event is invoked by Fabric.