### PR TITLE
Ability to specify an ID for a Temporary World

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/Fantasy.java
+++ b/src/main/java/xyz/nucleoid/fantasy/Fantasy.java
@@ -108,7 +108,23 @@ public final class Fantasy {
      * @return a future providing the created world
      */
     public RuntimeWorldHandle openTemporaryWorld(RuntimeWorldConfig config) {
-        RuntimeWorld world = this.addTemporaryWorld(config);
+        return this.openTemporaryWorld(generateTemporaryWorldKey(), config);
+    }
+
+    /**
+     * Creates a new temporary world with the given identifier and {@link RuntimeWorldConfig} that will not be saved and will be
+     * deleted when the server exits.
+     * <p>
+     * The created world is returned asynchronously through a {@link RuntimeWorldHandle}.
+     * This handle can be used to acquire the {@link ServerWorld} object through {@link RuntimeWorldHandle#asWorld()},
+     * as well as to delete the world through {@link RuntimeWorldHandle#delete()}.
+     *
+     * @param key the unique identifier for this dimension
+     * @param config the config with which to construct this temporary world
+     * @return a future providing the created world
+     */
+    public RuntimeWorldHandle openTemporaryWorld(Identifier key, RuntimeWorldConfig config) {
+        RuntimeWorld world = this.addTemporaryWorld(key, config);
         return new RuntimeWorldHandle(this, world);
     }
 
@@ -147,8 +163,8 @@ public final class Fantasy {
         return this.worldManager.add(worldKey, config, RuntimeWorld.Style.PERSISTENT);
     }
 
-    private RuntimeWorld addTemporaryWorld(RuntimeWorldConfig config) {
-        RegistryKey<World> worldKey = RegistryKey.of(RegistryKeys.WORLD, generateTemporaryWorldKey());
+    private RuntimeWorld addTemporaryWorld(Identifier key, RuntimeWorldConfig config) {
+        RegistryKey<World> worldKey = RegistryKey.of(RegistryKeys.WORLD, key);
 
         try {
             LevelStorage.Session session = this.serverAccess.getSession();

--- a/src/main/java/xyz/nucleoid/fantasy/Fantasy.java
+++ b/src/main/java/xyz/nucleoid/fantasy/Fantasy.java
@@ -187,7 +187,7 @@ public final class Fantasy {
         });
     }
 
-    private boolean tickDeleteWorld(ServerWorld world) {
+    public boolean tickDeleteWorld(ServerWorld world) {
         if (this.isWorldUnloaded(world)) {
             this.worldManager.delete(world);
             return true;
@@ -197,7 +197,7 @@ public final class Fantasy {
         }
     }
 
-    private boolean tickUnloadWorld(ServerWorld world) {
+    public boolean tickUnloadWorld(ServerWorld world) {
         if (this.isWorldUnloaded(world)) {
             this.worldManager.unload(world);
             return true;


### PR DESCRIPTION
- Adds the ability to specify an ID when opening a temporary world like a persistent one.
- Also adds the ability to manually tick a deleted or unloaded world.