### PR TITLE
Ability to specify if a world should mirror gamerules from the overworld

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldConfig.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldConfig.java
@@ -29,6 +29,7 @@ public final class RuntimeWorldConfig {
     private long timeOfDay = 6000;
     private Difficulty difficulty = Difficulty.NORMAL;
     private final GameRuleStore gameRules = new GameRuleStore();
+    private boolean mirrorOverworldGameRules = false;
     private RuntimeWorld.Constructor worldConstructor = RuntimeWorld::new;
 
     private int sunnyTime = Integer.MAX_VALUE;
@@ -94,6 +95,11 @@ public final class RuntimeWorldConfig {
 
     public RuntimeWorldConfig setGameRule(GameRules.Key<GameRules.IntRule> key, int value) {
         this.gameRules.set(key, value);
+        return this;
+    }
+
+    public RuntimeWorldConfig setMirrorOverworldGameRules(boolean mirror) {
+        this.mirrorOverworldGameRules = mirror;
         return this;
     }
 
@@ -176,6 +182,10 @@ public final class RuntimeWorldConfig {
 
     public GameRuleStore getGameRules() {
         return this.gameRules;
+    }
+
+    public boolean shouldMirrorOverworldGameRules(){
+        return this.mirrorOverworldGameRules;
     }
 
     public int getSunnyTime() {

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldProperties.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldProperties.java
@@ -19,6 +19,8 @@ public final class RuntimeWorldProperties extends UnmodifiableLevelProperties {
 
     @Override
     public GameRules getGameRules() {
+        if (this.config.shouldMirrorOverworldGameRules())
+            return super.getGameRules();
         return this.rules;
     }
 


### PR DESCRIPTION
Add ability to specify if a world should mirror gamerules from the overworld. 

Enabling this is vanilla custom dimension behavior.