### PR TITLE
Mirror overworld difficulty

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldConfig.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldConfig.java
@@ -30,6 +30,7 @@ public final class RuntimeWorldConfig {
     private Difficulty difficulty = Difficulty.NORMAL;
     private final GameRuleStore gameRules = new GameRuleStore();
     private boolean mirrorOverworldGameRules = false;
+    private boolean mirrorOverworldDifficulty = false;
     private RuntimeWorld.Constructor worldConstructor = RuntimeWorld::new;
 
     private int sunnyTime = Integer.MAX_VALUE;
@@ -204,6 +205,18 @@ public final class RuntimeWorldConfig {
     }
 
     /**
+     * Defines if the world should follow the overworld difficulty or not
+     *
+     * @param mirror Whenever it should mirror or not
+     *
+     * @return The same instance of RuntimeWorldConfig
+     */
+    public RuntimeWorldConfig setMirrorOverworldDifficulty(boolean mirror) {
+        this.mirrorOverworldDifficulty = mirror;
+        return this;
+    }
+
+    /**
      * Modifies the weather to sunny
      *
      * @param sunnyTime For how many ticks it should be sunny
@@ -336,16 +349,34 @@ public final class RuntimeWorldConfig {
         return this.timeOfDay;
     }
 
+    /**
+     * Gets the current configured difficulty
+     * <br/>
+     * <b>It may not reflect the real difficulty, also check </b>{@link RuntimeWorldConfig#shouldMirrorOverworldDifficulty()}
+     *
+     * @return The current difficulty stored in the config
+     */
     public Difficulty getDifficulty() {
         return this.difficulty;
     }
 
+    /**
+     * Gets the current configured gamerules
+     * <br/>
+     * <b>It may not reflect the real gamerules, also check </b>{@link RuntimeWorldConfig#shouldMirrorOverworldGameRules()}
+     *
+     * @return The current gamerules stored in the config
+     */
     public GameRuleStore getGameRules() {
         return this.gameRules;
     }
 
-    public boolean shouldMirrorOverworldGameRules(){
+    public boolean shouldMirrorOverworldGameRules() {
         return this.mirrorOverworldGameRules;
+    }
+
+    public boolean shouldMirrorOverworldDifficulty() {
+        return this.mirrorOverworldDifficulty;
     }
 
     public int getSunnyTime() {

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
@@ -34,7 +34,7 @@ final class RuntimeWorldManager {
         if (style == RuntimeWorld.Style.TEMPORARY) {
             ((FantasyDimensionOptions) (Object) options).fantasy$setSave(false);
         }
-        ((FantasyDimensionOptions) (Object) options).fantasy$setSaveProperties(false);
+        //((FantasyDimensionOptions) (Object) options).fantasy$setSaveProperties(false);
 
         SimpleRegistry<DimensionOptions> dimensionsRegistry = getDimensionsRegistry(this.server);
         boolean isFrozen = ((RemoveFromRegistry<?>) dimensionsRegistry).fantasy$isFrozen();

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
@@ -34,7 +34,7 @@ final class RuntimeWorldManager {
         if (style == RuntimeWorld.Style.TEMPORARY) {
             ((FantasyDimensionOptions) (Object) options).fantasy$setSave(false);
         }
-        //((FantasyDimensionOptions) (Object) options).fantasy$setSaveProperties(false);
+        ((FantasyDimensionOptions) (Object) options).fantasy$setSaveProperties(false);
 
         SimpleRegistry<DimensionOptions> dimensionsRegistry = getDimensionsRegistry(this.server);
         boolean isFrozen = ((RemoveFromRegistry<?>) dimensionsRegistry).fantasy$isFrozen();

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldProperties.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldProperties.java
@@ -19,8 +19,9 @@ public final class RuntimeWorldProperties extends UnmodifiableLevelProperties {
 
     @Override
     public GameRules getGameRules() {
-        if (this.config.shouldMirrorOverworldGameRules())
+        if (this.config.shouldMirrorOverworldGameRules()) {
             return super.getGameRules();
+        }
         return this.rules;
     }
 
@@ -86,6 +87,9 @@ public final class RuntimeWorldProperties extends UnmodifiableLevelProperties {
 
     @Override
     public Difficulty getDifficulty() {
+        if (this.config.shouldMirrorOverworldDifficulty()) {
+            return super.getDifficulty();
+        }
         return this.config.getDifficulty();
     }
 }


### PR DESCRIPTION
This branch is based on top of the RuntimeWorldConfig comments PR (#45)

It adds the option to mirror the overworld difficulty, allowing the same behavior as the nether and the end for the server difficulty