### PR TITLE
Fix issues with worlds that tick time (#54) - 1.20.6

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorld.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorld.java
@@ -62,6 +62,9 @@ public class RuntimeWorld extends ServerWorld {
         }
     }
 
+    /**
+    * Only use the time update code from super as the immutable world proerties runtime dimensions breaks scheduled functions
+    */
     @Override
     protected void tickTime() {
         if (this.shouldTickTime) {

--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorld.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorld.java
@@ -8,6 +8,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ProgressListener;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.random.RandomSequencesState;
+import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.source.BiomeAccess;
 import net.minecraft.world.dimension.DimensionOptions;
@@ -58,6 +59,15 @@ public class RuntimeWorld extends ServerWorld {
     public void save(@Nullable ProgressListener progressListener, boolean flush, boolean enabled) {
         if (this.style == Style.PERSISTENT || !flush) {
             super.save(progressListener, flush, enabled);
+        }
+    }
+
+    @Override
+    protected void tickTime() {
+        if (this.shouldTickTime) {
+            if (this.properties.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE)) {
+                this.setTimeOfDay(this.properties.getTimeOfDay() + 1L);
+            }
         }
     }
 

--- a/src/main/resources/fantasy.accesswidener
+++ b/src/main/resources/fantasy.accesswidener
@@ -3,3 +3,4 @@ accessWidener v1 named
 accessible class net/minecraft/server/world/ThreadedAnvilChunkStorage$EntityTracker
 
 accessible field net/minecraft/world/GameRules$IntRule value I
+accessible field net/minecraft/server/world/ServerWorld shouldTickTime Z

--- a/src/testmod/java/xyz/nucleoid/fantasy/test/FantasyInitializer.java
+++ b/src/testmod/java/xyz/nucleoid/fantasy/test/FantasyInitializer.java
@@ -11,8 +11,11 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.profiler.Profiler;
 import net.minecraft.world.TeleportTarget;
+import net.minecraft.world.biome.BiomeKeys;
+import net.minecraft.world.dimension.DimensionTypes;
+import net.minecraft.world.gen.chunk.FlatChunkGenerator;
+import net.minecraft.world.gen.chunk.FlatChunkGeneratorConfig;
 import org.slf4j.Logger;
 import xyz.nucleoid.fantasy.Fantasy;
 import xyz.nucleoid.fantasy.RuntimeWorldConfig;
@@ -20,7 +23,8 @@ import xyz.nucleoid.fantasy.RuntimeWorldHandle;
 import xyz.nucleoid.fantasy.util.VoidChunkGenerator;
 
 import java.util.HashMap;
-import java.util.WeakHashMap;
+import java.util.List;
+import java.util.Optional;
 
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
@@ -39,6 +43,15 @@ public final class FantasyInitializer implements ModInitializer {
             Fantasy.get(s).openTemporaryWorld(
                     new RuntimeWorldConfig().setGenerator(s.getOverworld().getChunkManager().getChunkGenerator()).setWorldConstructor(CustomWorld::new)
             );
+
+            var biome = s.getRegistryManager().get(RegistryKeys.BIOME).getEntry(s.getRegistryManager().get(RegistryKeys.BIOME).getOrThrow(BiomeKeys.PLAINS));
+            FlatChunkGeneratorConfig flat = new FlatChunkGeneratorConfig(Optional.empty(), biome, List.of());
+            FlatChunkGenerator generator = new FlatChunkGenerator(flat);
+
+            Fantasy.get(s).openTemporaryWorld(new RuntimeWorldConfig()
+                    .setDimensionType(DimensionTypes.OVERWORLD)
+                    .setGenerator(generator)
+                    .setShouldTickTime(true));
         });
 
         CommandRegistrationCallback.EVENT.register(((dispatcher, registryAccess, environment) -> {


### PR DESCRIPTION
This fixes the issue #54 by implementing only the daytime ticking on the tickTime method of the world
This PR is for Minecraft 1.20.6