### PR TITLE
Implement Option to Disable Warning Log for Failed World Deletion

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
@@ -57,7 +57,7 @@ final class RuntimeWorldManager {
         return world;
     }
 
-    void delete(ServerWorld world) {
+    void delete(ServerWorld world, boolean logDeletionFailure) {
         RegistryKey<World> dimensionKey = world.getRegistryKey();
 
         if (this.serverAccess.getWorlds().remove(dimensionKey, world)) {
@@ -72,7 +72,10 @@ final class RuntimeWorldManager {
                 try {
                     FileUtils.deleteDirectory(worldDirectory);
                 } catch (IOException e) {
-                    Fantasy.LOGGER.warn("Failed to delete world directory", e);
+                    if (logDeletionFailure) {
+                        Fantasy.LOGGER.warn("Failed to delete world directory", e);
+                    }
+
                     try {
                         FileUtils.forceDeleteOnExit(worldDirectory);
                     } catch (IOException ignored) {
@@ -80,6 +83,10 @@ final class RuntimeWorldManager {
                 }
             }
         }
+    }
+
+    void delete(ServerWorld world) {
+        this.delete(world, true);
     }
 
     void unload(ServerWorld world) {


### PR DESCRIPTION
Adds a boolean parameter to `RuntimeWorldManager#delete` to control whether to log errors during world deletion.

I frequently encounter a warning whenever I delete a world, cluttering my logs. I want to keep other warnings visible without adjusting my logging settings.

This change is somewhat niche, and it might overlook a potential issue where the folder is in use when `deleteDirectory` is called. However, `forceDeleteOnExit` manages the folder appropriately on exit, so a failure may not be a major concern in a multitude of use cases.