### PR TITLE
Forbid deleting the overworld - which would delete the save

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
@@ -60,6 +60,11 @@ final class RuntimeWorldManager {
     void delete(ServerWorld world) {
         RegistryKey<World> dimensionKey = world.getRegistryKey();
 
+        if (world == server.getOverworld()) {
+            Fantasy.LOGGER.error("Deleting minecraft:overworld is not supported - would delete the whole save");
+            return;
+        }
+
         if (this.serverAccess.getWorlds().remove(dimensionKey, world)) {
             ServerWorldEvents.UNLOAD.invoker().onWorldUnload(this.server, world);
 


### PR DESCRIPTION
Since the storage path for minecraft:overworld is the save's root dir, deleting it is a really bad idea.