### PR TITLE
Support world border in runtime worlds

### DIFF
--- a/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
+++ b/src/main/java/xyz/nucleoid/fantasy/RuntimeWorldManager.java
@@ -49,6 +49,10 @@ final class RuntimeWorldManager {
         RuntimeWorld world = config.getWorldConstructor().createWorld(this.server, worldKey, config, style);
 
         this.serverAccess.getWorlds().put(world.getRegistryKey(), world);
+
+        // setup world border data sender (named poorly in yarn mappings)
+        this.server.getPlayerManager().setMainWorld(world);
+
         ServerWorldEvents.LOAD.invoker().onWorldLoad(this.server, world);
 
         // tick the world to ensure it is ready for use right away


### PR DESCRIPTION
Since 1.21.9, each dimension now supports their own world border.
To make it work with runtime worlds, a world border listener has to be registered.
This is done by the PlayerManager.setMainWorld method (it is named poorly in yarn mappings, but does exactly that).